### PR TITLE
feat(api): implement local REST/HTTP bridge for lightweight agent integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+axum = "0.7"
+hyper = "1.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,74 @@
+//! REST/HTTP Bridge for 0-dex
+//! 
+//! Allows lightweight agents (Python/TS) to interact with the 0-dex node
+//! via simple HTTP requests without needing to implement libp2p or 0-lang locally.
+
+use axum::{
+    routing::{post, get},
+    Router, Json, extract::State, http::StatusCode,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::info;
+
+#[derive(Deserialize)]
+pub struct IntentRequest {
+    /// The raw .0 graph content as a string
+    pub graph_content: String,
+}
+
+#[derive(Serialize)]
+pub struct IntentResponse {
+    pub status: String,
+    pub message: String,
+}
+
+pub struct ApiState {
+    pub gossip_tx: mpsc::Sender<Vec<u8>>,
+}
+
+/// Start the REST API server
+pub async fn start_api_server(gossip_tx: mpsc::Sender<Vec<u8>>, port: u16) {
+    let state = Arc::new(ApiState { gossip_tx });
+
+    let app = Router::new()
+        .route("/health", get(health_check))
+        .route("/intent", post(submit_intent))
+        .with_state(state);
+
+    let addr = format!("0.0.0.0:{}", port);
+    info!("Starting REST/HTTP Bridge on http://{}", addr);
+    
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn health_check() -> &'static str {
+    "0-dex node is running"
+}
+
+async fn submit_intent(
+    State(state): State<Arc<ApiState>>,
+    Json(payload): Json<IntentRequest>,
+) -> Result<Json<IntentResponse>, (StatusCode, String)> {
+    let graph_bytes = payload.graph_content.into_bytes();
+    
+    // Send to the gossip network to be broadcasted
+    match state.gossip_tx.send(graph_bytes).await {
+        Ok(_) => {
+            info!("Successfully ingested external intent via REST API");
+            Ok(Json(IntentResponse {
+                status: "success".to_string(),
+                message: "Intent broadcasted to 0-dex mempool".to_string(),
+            }))
+        }
+        Err(e) => {
+            tracing::error!("Failed to broadcast intent: {}", e);
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to broadcast intent".to_string(),
+            ))
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod network;
 mod matching;
 mod settlement;
 mod vm_bridge;
+mod api;
 
 use network::GossipNode;
 use matching::MatchingEngine;
@@ -45,6 +46,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 4. Initialize and run the Matching Engine (Runs on main thread for now)
     info!("Starting 0-lang Matching Engine...");
     let mut matching_engine = MatchingEngine::new(match_tx);
+
+    // 5. Start the REST/HTTP Bridge for lightweight agents
+    // Clone the transmitter so the HTTP server can send graphs to the network
+    let api_gossip_tx = gossip_tx.clone();
+    tokio::spawn(async move {
+        api::start_api_server(api_gossip_tx, 8080).await;
+    });
 
     // Let the node run
     info!("0-dex node is running in serverless P2P mode.");


### PR DESCRIPTION
This PR tackles **Epic 0 (The Zero-Friction Viral Onboarding)** by adding a local HTTP server to the `0-dex` node using `axum`.

### Why?
To get maximum viral adoption, an indie dev writing an Agent in Python, TypeScript, or Go shouldn't need to compile a Rust libp2p node just to trade. They need a simple REST API.

### What this does:
- Spawns a lightweight `axum` HTTP server in the background (default port `8080`).
- Exposes `POST /intent` where Agents can simply submit a JSON payload containing their `.0` graph string.
- The API securely pipes this incoming graph directly into the core node's `mpsc::Sender`, which immediately broadcasts it to the `0-dex-mempool` via Gossipsub.

This turns the `0-dex` Rust binary into a highly accessible **sidecar** for any Agent framework.