### PR TITLE
feat(sdk): implement zero_dex_lite Python SDK with auto-signing and graph generators

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="zero-dex-lite",
+    version="0.1.0",
+    description="The Zero-Friction Python SDK for Agent-Native Trading on 0-dex",
+    packages=find_packages(),
+    install_requires=[
+        "requests>=2.25.0",
+        "eth-account>=0.8.0"
+    ],
+)

--- a/python/zero_dex_lite/__init__.py
+++ b/python/zero_dex_lite/__init__.py
@@ -1,0 +1,5 @@
+from .client import LiteClient
+from .generators import create_limit_order
+
+__version__ = "0.1.0"
+__all__ = ["LiteClient", "create_limit_order"]

--- a/python/zero_dex_lite/client.py
+++ b/python/zero_dex_lite/client.py
@@ -1,0 +1,50 @@
+import requests
+import json
+from eth_account import Account
+from eth_account.messages import encode_defunct
+
+class LiteClient:
+    """
+    Zero-Friction Python Client for 0-dex.
+    Allows any Agent to trade by speaking .0 graphs without knowing Rust or libp2p.
+    """
+    def __init__(self, private_key: str, gateway: str = "http://127.0.0.1:8080"):
+        self.gateway = gateway
+        self.account = Account.from_key(private_key)
+
+    def _sign_intent(self, graph_content: str) -> dict:
+        """
+        Cryptographically ties the 0-lang graph to the Agent's wallet.
+        Matches the \x190-dex Intent:\n length prefix hashing required by the Rust node.
+        """
+        prefix = f"\x190-dex Intent:\n{len(graph_content)}"
+        payload = prefix + graph_content
+        
+        # We use encode_defunct to hash the raw string
+        message = encode_defunct(text=payload)
+        signed_message = self.account.sign_message(message)
+        
+        return {
+            "graph_content": graph_content,
+            "owner_address": self.account.address,
+            "signature_hex": signed_message.signature.hex()
+        }
+
+    def broadcast_intent(self, graph_content: str) -> dict:
+        """
+        Signs the graph and broadcasts it to the P2P Gossip network via the local node/gateway.
+        """
+        signed_payload = self._sign_intent(graph_content)
+        
+        url = f"{self.gateway.rstrip('/')}/intent"
+        try:
+            response = requests.post(url, json=signed_payload)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Failed to broadcast intent: {e}")
+
+    def broadcast_intent_from_file(self, filepath: str) -> dict:
+        with open(filepath, "r") as f:
+            content = f.read()
+        return self.broadcast_intent(content)

--- a/python/zero_dex_lite/generators.py
+++ b/python/zero_dex_lite/generators.py
@@ -1,0 +1,21 @@
+def create_limit_order(buy_asset: str, sell_asset: str, min_price: float, amount: float) -> str:
+    """
+    Auto-generates a .0 graph for a standard limit order.
+    Agents can use this if they don't want to write raw 0-lang syntax.
+    """
+    return f"""# Auto-generated 0-lang limit order intent
+def buy_asset: "{buy_asset}"
+def sell_asset: "{sell_asset}"
+def min_price: {min_price}
+def amount: {amount}
+
+node CheckPrice {{
+  op: GreaterThanOrEqual
+  inputs: [Incoming.Price, min_price]
+}}
+
+node Output {{
+  op: ConditionalSwap
+  inputs: [CheckPrice.Output, buy_asset, sell_asset, amount]
+}}
+"""


### PR DESCRIPTION
This PR completes **Epic 0: The Zero-Friction Viral Onboarding** by providing a lightweight Python SDK for AI Agents.

### Why?
Agents written in Python shouldn't have to manually execute cryptographic hashing or raw HTTP posts to interact with `0-dex`.

### Features:
- **`LiteClient`**: A dead-simple client that takes a private key, automatically computes the `\x190-dex Intent:\n` Ethereum prefix hash, signs the graph via `eth_account`, and broadcasts it to the Rust node's HTTP bridge.
- **`generators.py`**: Helper functions to let Agents procedurally generate valid `.0` syntax (e.g. `create_limit_order`) without needing to understand the full AST of `0-lang`.

### Usage:
```python
from zero_dex_lite import LiteClient, create_limit_order

client = LiteClient(private_key="0x...")
graph = create_limit_order(buy_asset="ETH", sell_asset="USDC", min_price=3000, amount=1)
client.broadcast_intent(graph)
```